### PR TITLE
Improved overflow-x behavior when styling diffs

### DIFF
--- a/resources/public/com/bhauman/cljs-test-display/css/style.css
+++ b/resources/public/com/bhauman/cljs-test-display/css/style.css
@@ -175,7 +175,7 @@ pre {
     margin: 0px;
     word-break: normal;
     word-wrap: normal;
-    overflow-x: scroll;
+    overflow-x: auto;
     margin-top: 2px;
     margin-bottom: 2px;    
 }

--- a/resources/public/com/bhauman/cljs-test-display/css/style.css
+++ b/resources/public/com/bhauman/cljs-test-display/css/style.css
@@ -187,17 +187,15 @@ pre code {
 }
 
 .actual {
+    border-top: 1px dashed rgb(236, 196, 196);
     position: relative;
-}
-
-.actual pre {
-    margin-left: 20px;
 }
 
 .actual .arrow {
     position: absolute;
     font-size: 0.8em;
     top: 4px;
+    left: -18px;
 }
 
 /* errors */

--- a/test/cljs_testing/core_test.cljs
+++ b/test/cljs_testing/core_test.cljs
@@ -74,7 +74,8 @@
     (is (= 45 (reduce + (range 10))))
     (is (= 45 (reduce + (range 10))))
     (is (= 45 (reduce + (range 10))))
-    (is (= 45 (reduce + (range 10))))    
+    (is (= 45 (reduce + (range 10))))
+    (is (= (range 20) (range 19)))
     )
 
   (testing "a should be like b"


### PR DESCRIPTION
Minor change in diff styling that I found to be more readable, but appreciate this is an aesthetic change so may not be your cup of tea. 

The overflow issue may be specific to Chrome on Linux, but it looks like for Chrome every `pre` has a scrollbar. This does not appear to be the case for Firefox, but in Firefox both `overflow-x: scroll` and `overflow-x: auto` appear to result in the same visual behavior, where the overflow scrollbar is conditional. I've added one failing test example with overflow to help demonstrate the styling issue.

The other styling change is I lined up the `actual` result with the `expected`, moved the red arrow into the gutter prior to the `actual`, and then added a faint dashed line to help separate the two visually. As the `actual` result can sometimes scroll, it's nice to avoid indenting it with the arrow to ensure we get most of the available width. I think I'm also just partial to the expected and actual `pre` blocks lining up. I'm happy to back out the arrow/dashed line change as I think the overflow issue is the more annoying problem, but thought I would at least see if the new style was appreciated first.

The new styling looks like:
![image](https://user-images.githubusercontent.com/6784/179256026-0f1fa5ba-dc58-41fa-bcbb-119cd38963ba.png)

Where-as previously it would show scrollbars everywhere:
![image](https://user-images.githubusercontent.com/6784/179259371-0ed03310-f08b-43ff-8379-4e74a3bc5f4d.png)

Thanks again for this wonderful test display library!